### PR TITLE
WeaponAttackZoneSelection

### DIFF
--- a/dreadnought.py
+++ b/dreadnought.py
@@ -1,39 +1,60 @@
 # dreadnought(player) file
 # will handle basic logic and functionality for the dreadnought(player)
+# # (utlized heavily by enemy ai)
 # will rely on other classes/files: (weapon.py)
-#
+
+
 from weapons import Weapon
 
 class Dreadnought:
 	#
-	# playerWeaponPairSynergyMap = {
-		# frozenset(["ExampleWeapon1", "ExampleWeapon2"]): "ExampleWeaponSynergyAttack1",
-		# frozenset(["ExampleWeaponA", "ExampleWeaponB"]): "ExampleWeaponSynergyAttack2",
+	# playerWeaponPairSynergyMap = { # handle with dictionary keyed by pairs of weapon types ?
+	# 	frozenset(["ExampleWeapon1", "ExampleWeapon2"]): "ExampleWeaponSynergyAttack1",
+	# 	frozenset(["ExampleWeaponA", "ExampleWeaponB"]): "ExampleWeaponSynergyAttack2",
 	# }
 	#
 	
-	def __init__(self, name, HealthPoints, leftWeapon, rightWeapon):
+	def __init__(self, name, healthPoints, leftWeapon, rightWeapon): # rename HealthPoints as healthPoints ?
+		#NFR #24
 		self.name = name
-		self.HealthPoints = HealthPoints
+		self.healthPoints = healthPoints
 		self.leftWeapon = leftWeapon
 		self.rightWeapon = rightWeapon
 
-	def attackWithLeftWeapon(self):
+	def attackWithLeftWeapon(self, occupantPosition, target): # ! occupantPosition, and target not yet defined within attackWithXWeapon
 		# temp dreadnought weapon attack(LEFT ARM) (will require user confirmation to confirm attack)
+		chosenAttackZone = self._chooseWeaponAttackZone(self.leftWeapon) # utilize pvt helper to select where to attack
 		print(f"{self.name} performs an attack with it's (LEFT) ({self.leftWeapon.name})!")
 		self.leftWeapon.weaponAttack(occupantPosition, target)
 
-	def attackWithRightWeapon(self):
+	def attackWithRightWeapon(self, occupantPosition, target):
 		# temp dreadnought weapon attack (RIGHT ARM) (will require user confirmation to confirm attack)
+		chosenAttackZone = self._chooseWeaponAttackZone(self.rightWeapon) # utilize pvt helper to select where to attack
 		print(f"{self.name} performs an attack with it's (RIGHT) ({self.rightWeapon.name})!")
 		self.rightWeapon.weaponAttack(occupantPosition, target)
 
-	def isAlive(self):
-		return self.HealthPoints > 0
+	def _chooseWeaponAttackZone(self, weapon): # pvt helper used to select which attackZone to attack when attacking with a weapon
+		attackZoneOptions = weapon.getWeaponAttackZoneOptions()
+		print(f"{weapon.name} can attack in one of the following zones:")
+		for i, attackZone in enumerate(attackZoneOptions):
+			print(f"{i}) {sorted(attackZone)}")
 
-	def takeDamage(amount: int): # when a dreadnought is hit for damage
-		self.HealthPoints -= amount
+		while True:
+			choice = input("Select an attackZone index to attack: ")
+			try:
+				choiceInt = int(choice)
+				chosenAttackZone = attackZoneOptions[choiceInt]
+				return chosenAttackZone
+			except(ValueError, IndexError):
+				print("Error: Invalid attackZone choice.")
+
+	def isAlive(self):
+		return self.healthPoints > 0
+
+	def takeDamage(self, amount: int): # self ?, amount: int ? ~~ correct ?
+	# when a dreadnought is hit for damage
+		self.healthPoints -= amount
 		if not self.isAlive(): # check if dead
-			printf("{self.name} has been destroyed!") # temp
+			print(f"{self.name} has been destroyed!") # temp
 			# remove from game, end game etc...
 			

--- a/weapons.py
+++ b/weapons.py
@@ -9,37 +9,39 @@
 #
 
 class Weapon:
-	# weaponRange rename?
-	# add ammoCapacity for weapons requiring ammunition?
-	def __init__(self, name, damage, weaponRange):
+	# add ammoCapacity for weapons requiring ammunition ?
+	# add weaponPairSpecialAttack ?
+
+	def __init__(self, name, damage): #weaponRange
 		self.name = name
 		self.damage = damage
-		self.weaponRange = [] # name attackZone?
+		# self.weaponRange = [] # ! change to self.weaponRange = weaponRange ? (name attackZone?)
 
-	def getWeaponRange(self):
-		return self.weaponRange
+	#def getWeaponRange(self):
+	#	return self.weaponRange
 
-	# weapon attack logic? or will that be in combat/player/ect file?
-	def weaponAttack(self, occupantPosition, targetDreadnought):
-		# temporary basic weapon attack logic, text (always hits static zone) 
-		if occupantPosition in self.weaponRange:
-			# Hit = character damage == weaponDamage
+	def getWeaponAttackZoneOptions(self): # for dynamic weaponRange/AttackZone selection
+		return []
+
+	def weaponAttack(self, selectedAttackZone, occupantPosition, targetDreadnought):
+		# temporary basic weapon attack logic, text (Weapons always hits their static zone) 
+		if occupantPosition in selectedAttackZone:
 			print(f"{self.name} hit at tile: {occupantPosition} for {self.damage} damage.")
-		else:
-			# Miss = no character damage
+			if targetDreadnought: # if dreadnought in attackZone -> Hit -> character damage == weaponDamage
+				targetDreadnought.takeDamage(self.damage)
+		else: # Miss = no character damage
 			print(f"{self.name} missed at tile: {occupantPosition}.")
-
-	def displayWeaponStats(self):
-		# FR#22 When weapon is selected and indicator will present the stats and attack pattern
+			
+	def displayWeaponStats(self): # for UI
 		# will need to visually indicate, but for now just print
 		print(f"Selected Weapon: {self.name}")
 		print(f"Weapon Damage: {self.damage}")
-		self.displayWeaponAttackGrid # needs integration with pygame / visuals
+		self.displayWeaponAttackGrid() # needs integration with pygame / visuals
 
-	def displayWeaponAttackGrid(self):
+	def displayWeaponAttackGrid(self): # utlized by displayWeaponStats
 		# shows grid representation of weapon attack zone(1's = hit zone)
 		print(f"{self.name}: Attack Pattern:")
-		for row in range(3):
+		for row in range(3): # make dynamic?
 			rowRepr = []
 			for col in range(3):
 				if (row, col) in self.weaponRange:
@@ -57,8 +59,15 @@ class Bolter(Weapon):
 		super().__init__(
 			name = "Bolter", #placeholder
 			damage = 2, # temp
-			weaponRange = [(1, 0), (1, 1), (1, 2)], # middle row for now
+			# weaponRange = [(1, 0), (1, 1), (1, 2)], # middle row for now
 			)
+
+	def getWeaponAttackZoneOptions(self): # possible attackZones for weapon
+		# Bolter has straight line attackPattern (1 row)
+		row0 = {(0, 0), (0, 1), (0, 2)}
+		row1 = {(1, 0), (1, 1), (1, 2)}
+		row2 = {(2, 0), (2, 1), (2, 2)}
+		return [row0, row1, row2]
 
 class MeleeWeapon1(Weapon):
 # weapon #2: MeleeWeapon1(placeholder, Powerfist, Chainfist, Chain-axe/sword, etc..): high dmg, Single tile attack?
@@ -66,23 +75,42 @@ class MeleeWeapon1(Weapon):
 	def __init__(self):
 		super().__init__(
 			name = "MeleeWeapon1", #placeholder
-			damage = 3, # temp
-			weaponRange = [(0, 0), (1, 0), (2, 0)], # single? (first column for now)
+			damage = 2, # temp
+			# weaponRange = [(0, 0), (1, 0), (2, 0)], # single? (first column for now)
 			)
 
-class AOEWeapon1(Weapon):
-# weapon #3: AOEWeapon1(placeholder, Flamer, Assault-Cannon, etc.: , base dmg?, Multi-tile pattern attack(AOE).
+	def getWeaponAttackZoneOptions(self): # possible attackZones for weapon
+		# MeleeWeapon1 has straight column attackPattern (1 columnn) (eventually limit to only front column?)
+		# - for now can hit any 1 column
+		col0 = {(0, 0), (1, 0), (2, 0)}
+		col1 = {(0, 1), (1, 1), (2, 1)}
+		col2 = {(0, 2), (1, 2), (2, 2)}
+		return [col0, col1, col2]
+
+class AOEWeapon1(Weapon): # will rename to either KrakMissileLauncher or FragMissileLauncher, then add the latter.
+# weapon#3: name: AOEWeapon1, dmg: temp, attackZone: AOE/Concentrated explosion,
 
 	def __init__(self):
 		super().__init__(
 			name = "AOEWeapon1",
-			damage = 1, # temp
-			weaponRange = [ # back 2 columns for now
-				(0, 1), (0, 2),
-				(1, 1), (1, 2),
-				(2, 1), (2, 2)
-			], 
+			damage = 2, # temp
+			# weaponRange = [ # back 2 columns for now
+			# 	(0, 1), (0, 2),
+			# 	(1, 1), (1, 2),
+			# 	(2, 1), (2, 2)
+			# ], 
 			)
+
+	def getWeaponAttackZoneOptions(self): # possible attackZones for weapon
+		# MissileLauncher for now hits a 2x2 'square' selection of tiles on the grid
+		topLeftCornerCoordinates = [(0, 0), (0, 1), (1, 0), (1, 1)]
+		attackZoneOptions = []
+		for (row, column) in topLeftCornerCoordinates:
+			attackZone = {
+				(row, column), (row, column + 1), (row + 1, column), (row + 1, column + 1)
+			}
+			attackZoneOptions.append(attackZone)
+		return attackZoneOptions
 
 class AssaultCannon(Weapon):
 # weapon #4: AOEWeapon2(placeholder, Flamer, Assault-Cannon, etc.: , base dmg?, Multi-tile pattern attack(AOE).
@@ -91,10 +119,19 @@ class AssaultCannon(Weapon):
 		super().__init__(
 			name = "AssaultCannon",
 			damage = 2, # temp
-			weaponRange = [ # every other tile hit. (scatter)
-				(0, 0), (0, 2),
-				(1, 1),
-				(2, 0), (2, 2)
-			], 
+			# weaponRange = [ # every other tile hit. (scatter) for now.
+			# 	(0, 0), (0, 2),
+			# 	(1, 1),
+			# 	(2, 0), (2, 2)
+			# ], 
 			)
 
+	def getWeaponAttackZoneOptions(self): # possible attackZones for weapon
+		# AssaultCannon for now hits any two tiles (adjacent) in the same column. (choosing from pairs of vertically adjacent tiles)
+		attackZoneOptions = []
+		for col in range(3):
+			attackZone1 = {(0, col), (1, col)}
+			attackZone2 = {(1, col), (2, col)}
+			attackZoneOptions.append(attackZone1)
+			attackZoneOptions.append(attackZone2)
+		return attackZoneOptions


### PR DESCRIPTION
Added/Reworked weapon/dreadnought logic so that now weapons do not have static weaponRanges, and instead have weaponAttackZone options that can be accessed with getWeaponAttackZoneOptions.

This means that when a dreadnought attacks with one of its arm's weapons, it will prompt the player (or AI) to select one of the possible attackZone options that the weapon has to make the attack at. This required adding some (likely temporary) changes to the attackZones of the weapons (Ie Assault cannon hits in different pattern for now).