### PR TITLE
Tunajim/integrate menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from playerMovement import PlayerMovement
 from constants import SCREEN_WIDTH, SCREEN_HEIGHT, GRID_ROWS, GRID_COLS, RED, WHITE, BLUE, GREEN
 import mechInit
 import enemyai
+import menu
+import game_state
 
 def run_grid_game():
     pg.init()
@@ -28,6 +30,9 @@ def run_grid_game():
     # set up the screen
     screen = pg.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
     pg.display.set_caption("Rouge Dreadnaught 2025")
+
+    gameState = game_state.GameState()
+    menuController = menu.MenuController(gameState, pg, screen)
 
     #load music
     # music source - https://downloads.khinsider.com/game-soundtracks/album/warhammer-40k-space-marine-ost/08.%2520The%2520Blood%2520Ravens.mp3
@@ -77,121 +82,137 @@ def run_grid_game():
 
     running = True
     while running:
-        # background
-        screen.blit(background_image, (0, 0))
 
-        #enemy combat log
-        if enemy_logging:
-            for i in range(9):
-                combat_log[i] = combat_font.render(combat_log_text[i], 1, WHITE)
-                screen.blit(combat_log[i], (SCREEN_WIDTH-180,(SCREEN_HEIGHT/2)-11*i))
+        # Initially load to the main menu
+        if(gameState.currentState() == game_state.State.MAIN_MENU):
 
-        #color timer for damage animation
-        if damage_timer:
-            damage_timer -= 1
+            # The following menuLoop will pause the while loop until the menu is exited
+            # Exiting to the main menu from in game menu, will bring us back to this code block
+            # We can reinitialize the appropriate variables here, so that the game can be restarted
 
-        # grid and highlight
-        # Inside your main game loop for drawing:
-        for row in range(GRID_ROWS):
-            for col in range(GRID_COLS):
-                # offset for angeled grid
-                extra_offset = row * (CELL_WIDTH * 0.3)  
-                # shift each row
-                rect = pg.Rect(col * CELL_WIDTH + GRID_X_OFFSET - extra_offset,
-                               row * CELL_HEIGHT + GRID_Y_OFFSET,
-                               CELL_WIDTH, CELL_HEIGHT)
-                pg.draw.rect(screen, WHITE, rect, 1)  # Draw grid outline
+            menuController.menuLoop(pg.event.get())
+        else:
+            # background
+            screen.blit(background_image, (0, 0))
 
-                # highlight player's cell if this is the current position.
-                if player_grid.get_player_position() == (row, col):
-                    if damage_timer:
-                        pg.draw.rect(screen, RED, rect.inflate(-CELL_WIDTH * 0.1, -CELL_HEIGHT * 0.1))
-                    else:
+            #enemy combat log
+            if enemy_logging:
+                for i in range(9):
+                    combat_log[i] = combat_font.render(combat_log_text[i], 1, WHITE)
+                    screen.blit(combat_log[i], (SCREEN_WIDTH-180,(SCREEN_HEIGHT/2)-11*i))
+
+            #color timer for damage animation
+            if damage_timer:
+                damage_timer -= 1
+
+            # grid and highlight
+            # Inside your main game loop for drawing:
+            for row in range(GRID_ROWS):
+                for col in range(GRID_COLS):
+                    # offset for angeled grid
+                    extra_offset = row * (CELL_WIDTH * 0.3)  
+                    # shift each row
+                    rect = pg.Rect(col * CELL_WIDTH + GRID_X_OFFSET - extra_offset,
+                                row * CELL_HEIGHT + GRID_Y_OFFSET,
+                                CELL_WIDTH, CELL_HEIGHT)
+                    pg.draw.rect(screen, WHITE, rect, 1)  # Draw grid outline
+
+                    # highlight player's cell if this is the current position.
+                    if player_grid.get_player_position() == (row, col):
+                        if damage_timer:
+                            pg.draw.rect(screen, RED, rect.inflate(-CELL_WIDTH * 0.1, -CELL_HEIGHT * 0.1))
+                        else:
+                            pg.draw.rect(screen, GREEN, rect.inflate(-CELL_WIDTH * 0.1, -CELL_HEIGHT * 0.1))
+
+            # positioning for the mech image, offset slightly to appear standing on the square
+            player_row, player_col = player_grid.get_player_position()
+            extra_offset = player_row * (CELL_WIDTH * 0.3)
+            cell_x = player_col * CELL_WIDTH + GRID_X_OFFSET - extra_offset
+            cell_y = player_row * CELL_HEIGHT + GRID_Y_OFFSET
+            img_width, img_height = player_image.get_size()
+            image_x = cell_x + (CELL_WIDTH - img_width) // 2
+            image_y = cell_y + (CELL_HEIGHT - img_height) // 2 - 50
+            screen.blit(player_image, (image_x, image_y))
+            
+
+            # grid and highlight for the enemy
+            for row in range(GRID_ROWS):
+                for col in range(GRID_COLS):
+                    # offset for angeled grid
+                    extra_offset = row * (CELL_WIDTH * .3)  
+                    # shift each row
+                    rect = pg.Rect(col * CELL_WIDTH + GRID_X_OFFSET + extra_offset+500,
+                                row * CELL_HEIGHT + GRID_Y_OFFSET,
+                                CELL_WIDTH, CELL_HEIGHT)
+                    pg.draw.rect(screen, WHITE, rect, 1)  # Draw grid outline
+
+                    # highlight player's cell if this is the current position.
+                    if games_mechs.Get_Enemy_Position() == (row, col):
                         pg.draw.rect(screen, GREEN, rect.inflate(-CELL_WIDTH * 0.1, -CELL_HEIGHT * 0.1))
 
-        # positioning for the mech image, offset slightly to appear standing on the square
-        player_row, player_col = player_grid.get_player_position()
-        extra_offset = player_row * (CELL_WIDTH * 0.3)
-        cell_x = player_col * CELL_WIDTH + GRID_X_OFFSET - extra_offset
-        cell_y = player_row * CELL_HEIGHT + GRID_Y_OFFSET
-        img_width, img_height = player_image.get_size()
-        image_x = cell_x + (CELL_WIDTH - img_width) // 2
-        image_y = cell_y + (CELL_HEIGHT - img_height) // 2 - 50
-        screen.blit(player_image, (image_x, image_y))
-        
-
-        # grid and highlight for the enemy
-        for row in range(GRID_ROWS):
-            for col in range(GRID_COLS):
-                # offset for angeled grid
-                extra_offset = row * (CELL_WIDTH * .3)  
-                # shift each row
-                rect = pg.Rect(col * CELL_WIDTH + GRID_X_OFFSET + extra_offset+500,
-                               row * CELL_HEIGHT + GRID_Y_OFFSET,
-                               CELL_WIDTH, CELL_HEIGHT)
-                pg.draw.rect(screen, WHITE, rect, 1)  # Draw grid outline
-
-                # highlight player's cell if this is the current position.
-                if games_mechs.Get_Enemy_Position() == (row, col):
-                    pg.draw.rect(screen, GREEN, rect.inflate(-CELL_WIDTH * 0.1, -CELL_HEIGHT * 0.1))
-
-        # event handling
-        for event in pg.event.get():
-            if event.type == pg.QUIT:
-                running = False
-
-            elif event.type == pg.KEYDOWN:
-                if event.key == pg.K_ESCAPE:
+            # event handling
+            for event in pg.event.get():
+                if event.type == pg.QUIT:
                     running = False
-                elif event.key in KEY_TO_DIRECTION:
-                    direction = KEY_TO_DIRECTION[event.key]
-                    player_movement.move_player(direction)
-                    #whenever the player takes a turn the enemy can take one only change
-                    #enemy_turn to 1 when the enemy gets a turn
-                    enemies_turn = 1
-                    damage_timer = 0
 
-            elif event.type == pg.MOUSEBUTTONDOWN:
-                mouse_x, mouse_y = pg.mouse.get_pos()
-                # check the click is within the grid
-                if (mouse_y >= GRID_Y_OFFSET and 
-                    mouse_y < GRID_Y_OFFSET + CELL_HEIGHT * GRID_ROWS):
-                    clicked_row = int((mouse_y - GRID_Y_OFFSET) // CELL_HEIGHT)
-                    adjusted_mouse_x = mouse_x - GRID_X_OFFSET + (clicked_row * (CELL_WIDTH * 0.3))
-                    if adjusted_mouse_x >= 0 and adjusted_mouse_x < CELL_WIDTH * GRID_COLS:
-                        clicked_col = int(adjusted_mouse_x // CELL_WIDTH)
-                        # get position
-                        player_row, player_col = player_grid.get_player_position()
-                        # allow if adjacent or diagonal
-                        if (abs(clicked_row - player_row) <= 1 and 
-                            abs(clicked_col - player_col) <= 1 and 
-                            not (clicked_row == player_row and clicked_col == player_col)):
-                            player_grid.place_player((clicked_row, clicked_col))
-                            #whenever the player takes a turn the enemy can take one only change
-                            #enemy_turn to 1 when the enemy gets a turn
-                            enemies_turn = 1
-                            damage_timer = 0
+                elif event.type == pg.KEYDOWN:
+                    if event.key == pg.K_ESCAPE:
 
-        #enemyai takes enemies turn
-        if enemies_turn:
-            action = enemy_ai.Take_Action()
-            turn_counter += 1
-            for i in range(9):
-                combat_log_text[9-i] = combat_log_text[8-i]
-            if action == 1:
-                combat_log_text[0] = "Action "+str(turn_counter)+": The enemy is defending"
-            elif action == 2:
-                combat_log_text[0] = "Action "+str(turn_counter)+": The enemy made a move"
-            else:
-                combat_log_text[0] = "Action "+str(turn_counter)+": The enemy has attacked"
-                damage_timer = 20
-            enemies_turn = 0
-            if games_mechs.playerMech.healthPoints <= 0:
-                you_died_text = you_died_font.render('You have died!', 1, RED)
-        screen.blit(you_died_text, (370,200))
+                        # On escape, bring up the in game menu
 
-        pg.display.flip()
-        clock.tick(60)
+                        gameState.setMenuActive(True)
+                        menuController.menuLoop(pg.event.get())
+
+                        # running = False
+                    elif event.key in KEY_TO_DIRECTION:
+                        direction = KEY_TO_DIRECTION[event.key]
+                        player_movement.move_player(direction)
+                        #whenever the player takes a turn the enemy can take one only change
+                        #enemy_turn to 1 when the enemy gets a turn
+                        enemies_turn = 1
+                        damage_timer = 0
+
+                elif event.type == pg.MOUSEBUTTONDOWN:
+                    mouse_x, mouse_y = pg.mouse.get_pos()
+                    # check the click is within the grid
+                    if (mouse_y >= GRID_Y_OFFSET and 
+                        mouse_y < GRID_Y_OFFSET + CELL_HEIGHT * GRID_ROWS):
+                        clicked_row = int((mouse_y - GRID_Y_OFFSET) // CELL_HEIGHT)
+                        adjusted_mouse_x = mouse_x - GRID_X_OFFSET + (clicked_row * (CELL_WIDTH * 0.3))
+                        if adjusted_mouse_x >= 0 and adjusted_mouse_x < CELL_WIDTH * GRID_COLS:
+                            clicked_col = int(adjusted_mouse_x // CELL_WIDTH)
+                            # get position
+                            player_row, player_col = player_grid.get_player_position()
+                            # allow if adjacent or diagonal
+                            if (abs(clicked_row - player_row) <= 1 and 
+                                abs(clicked_col - player_col) <= 1 and 
+                                not (clicked_row == player_row and clicked_col == player_col)):
+                                player_grid.place_player((clicked_row, clicked_col))
+                                #whenever the player takes a turn the enemy can take one only change
+                                #enemy_turn to 1 when the enemy gets a turn
+                                enemies_turn = 1
+                                damage_timer = 0
+
+            #enemyai takes enemies turn
+            if enemies_turn:
+                action = enemy_ai.Take_Action()
+                turn_counter += 1
+                for i in range(9):
+                    combat_log_text[9-i] = combat_log_text[8-i]
+                if action == 1:
+                    combat_log_text[0] = "Action "+str(turn_counter)+": The enemy is defending"
+                elif action == 2:
+                    combat_log_text[0] = "Action "+str(turn_counter)+": The enemy made a move"
+                else:
+                    combat_log_text[0] = "Action "+str(turn_counter)+": The enemy has attacked"
+                    damage_timer = 20
+                enemies_turn = 0
+                if games_mechs.playerMech.healthPoints <= 0:
+                    you_died_text = you_died_font.render('You have died!', 1, RED)
+            screen.blit(you_died_text, (370,200))
+
+            pg.display.flip()
+            clock.tick(60)
 
     pg.quit()
 

--- a/menu.py
+++ b/menu.py
@@ -39,6 +39,8 @@ class MenuController:
 		self.currentMenu = MenuType.EMPTY
 		self.mainTheme = themes.THEME_BLUE
 
+		self.j = 0
+
 
 		# This is just a placeholder variable
 		# difficulty will be tracked in a state machine
@@ -58,17 +60,23 @@ class MenuController:
 	'''
 	def menuLoop(self, events):
 
-		# If theres no menu, set up the correct one
+
+		print("Menu Loop")
+
+		print("TESTING")
+		print(self.gameState.currentState())
+
 		if self.menu == MenuType.EMPTY and self.gameState.getMenuActive():
 			match self.stage:
 				case 0:
 					self.setMenu(MenuType.MAIN)
 				case 1:
 					self.setMenu(MenuType.IN_GAME)
-
-		# Only draw the menu if the menu has been properly set
-		if self.menu != MenuType.EMPTY:
-			self.drawMenu(events)
+		
+		if self.gameState.currentState().value == 1 and self.gameState.getMenuActive():
+			if(self.gameState.getMenuActive()): #james smells like cheese -Oscar
+				self.setMenu(MenuType.IN_GAME)
+			self._initInGameMenu()
 
 
 	def setMenu(self, menuType):
@@ -84,13 +92,15 @@ class MenuController:
 	def drawMenu(self, events):
 		self.menu.update(events)
 		if(type(self.menu) == pygame_menu.menu.Menu):
-			self.menu.draw(self.screen)
+			self.menu.mainloop(self.screen)
 
 
 	# Landing page menus
 
 	# Main menu where player can change difficult, enter game, or exit
 	def _initMainMenu(self):
+		if(self.menu != MenuType.EMPTY):
+			self.menu.disable()
 		# indicate main menu stage
 		self.stage = 0  
 
@@ -106,10 +116,13 @@ class MenuController:
 		self.menu.add.button("Change Difficulty", self._initDifficultyMenu)
 		self.menu.add.button("Exit", self._terminate)
 
+		self.menu.mainloop(self.screen)
+
 		print(" - Initialized main menu - ")
 
 	# Start the game
 	def _play(self):
+		self.menu.disable()
 
 		# discard the current menu 
 		self.menu = MenuType.EMPTY
@@ -122,7 +135,11 @@ class MenuController:
 		self.gameState.setMenuActive(False)
 		self.gameState.setGameActive(True)
 
+
+		print(self.gameState.currentState())
+
 		print(" - Beginning game - ")
+		pygame_menu.events.EXIT
 
 	def _terminate(self):
 		self.pg.quit()
@@ -130,6 +147,8 @@ class MenuController:
 		sys.exit()
 
 	def _initDifficultyMenu(self):
+		if(self.menu != MenuType.EMPTY):
+			self.menu.disable()
 		self.menu = pygame_menu.Menu(
 			"Select Difficulty",
 			self.width, self.height,
@@ -156,6 +175,7 @@ class MenuController:
 		self.menu.add.button("Hard", self._setDifficulty, Difficulty.HARD)
 		self.menu.add.button("Back", self._initMainMenu)
 
+		self.menu.mainloop(self.screen)
 		print(" - Initialized difficulty menu - ")
 	
 	def _setDifficulty(self, difficulty: Difficulty):
@@ -165,6 +185,9 @@ class MenuController:
 
 	# In game menus
 	def _initInGameMenu(self):
+		print(" - Initializing in game menu - ")
+		if(self.menu != MenuType.EMPTY):
+			self.menu.disable()
 		self.menu = pygame_menu.Menu(
 			"Game Paused",
 			self.width / 2, self.height / 2,
@@ -173,20 +196,19 @@ class MenuController:
 
 		self.menu.add.button('Resume', self._resume)
 		self.menu.add.button('Quit', self._initMainMenu)
+		self.menu.mainloop(self.screen)
 		print(" - Initialized in game menu - ")
 	
 	def _setAudioPreference(self, active: bool, volume: int):
 		self.gameState.setMusicActive(active)
 
-	def _fadeMenu(self, timeout):
-		self.mainTheme.set_background_color_opacity = 0.5
 
 
 	
 	def _resume(self):
-		self._fadeMenu(100)
-		# self.menu = MenuType.EMPTY
-		# self.gameState.setMenuActive(False)
+		self.menu.disable()
+		self.menu = MenuType.EMPTY
+		self.gameState.setMenuActive(False)
 
 
 class TestMenuController(unittest.TestCase):


### PR DESCRIPTION
I've adapted the main file to accommodate the menus.  It simply wraps the previous code in a check to see if the player is in the main menu.  This code block is a perfect place to add game reset logic, where we can reinitialize the appropriate variables to restart.  In addition, when player presses escape in game, it will mount the in-game menu, where they can resume the game or return to main menu.  